### PR TITLE
fix: add warning log when NEXTENDO env vars are missing (S-CRIT-4)

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -44,7 +44,14 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
         {
             string value = Environment.GetEnvironmentVariable(envVar);
 
-            return IPAddress.TryParse(value, out IPAddress address) ? address : IPAddress.Loopback;
+            if (!IPAddress.TryParse(value, out IPAddress address))
+            {
+                Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"DnsMitmResolver: {envVar} not set, falling back to loopback — Nintendo hosts will resolve to 127.0.0.1");
+
+                return IPAddress.Loopback;
+            }
+
+            return address;
         }
 
         private static bool TryMatchBuiltin(string host, out IPAddress address)


### PR DESCRIPTION
Adds Logger.Warning when NEXTENDO_SERVER_IP or NEXTENDO_NAT_IP are not defined, so users know why traffic is being redirected to loopback instead of silently failing.

Closes S-CRIT-4