### PR TITLE
nsd: cut hostname at first NUL instead of TrimEnd

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
@@ -77,7 +77,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager
 
             context.Memory.Read(inputPosition, addressBuffer);
 
-            string address = Encoding.UTF8.GetString(addressBuffer).TrimEnd('\0');
+            string address = Encoding.UTF8.GetString(addressBuffer);
+            int nullIdx = address.IndexOf('\0');
+            if (nullIdx >= 0) address = address.Substring(0, nullIdx);
 
             resultCode = Resolve(address, out resolvedAddress);
 


### PR DESCRIPTION
The guest FQDN buffer can contain data after the hostname terminator; TrimEnd('\\0') left that garbage in the lookup string and made the resolution fail. Cut the string at the first NUL instead.

Verified: fixes NSD hostname resolution for Nintendo online titles.