### PR TITLE
DnsMitmResolver: route Mario Tennis Aces through real GeoDNS

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -381,16 +381,19 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
             // GeoDNS hostname instead of the fixed NEXTENDO_SERVER_IP, so players get routed to
             // whichever of the two live Tennis nodes is actually closest to them. Every other
             // title is unaffected -- the second node doesn't run their servers. Gated on
-            // !NextendoServerOverride.IsActive: a player running a custom/private server must
-            // not have Tennis silently pulled onto our nodes instead of theirs (caught in
-            // review -- this branch used to run ahead of Substituer()'s override check).
-            // NEXTENDO_TENNIS_GEODNS=0 disables this and falls through to the normal built-in
-            // redirect below. The lookup is bounded to 2s: the GeoDNS delegation has only one
-            // nameserver behind it, and Dns.GetHostEntry has no native timeout, so an unbounded
-            // call here could hang indefinitely if that nameserver is unreachable. Falls through
-            // the same way on any resolution failure or timeout rather than failing the
-            // connection outright.
-            if (!NextendoServerOverride.IsActive &&
+            // !NextendoServerOverride.HorsNextendo, not IsActive: IsActive also requires the
+            // typed address to parse, so a fat-fingered custom-server IP would leave IsActive
+            // false and this branch would still fire, sending them to our nameserver and onto
+            // our nodes. HorsNextendo is true as soon as the box is ticked regardless of what
+            // was typed -- exactly the "don't silently put them back on our servers" case its
+            // own doc comment describes, and what every other Nextendo redirect gates on
+            // (caught by Kazu in review). NEXTENDO_TENNIS_GEODNS=0 disables this and falls
+            // through to the normal built-in redirect below. The lookup is bounded to 2s: the
+            // GeoDNS delegation has only one nameserver behind it, and Dns.GetHostEntry has no
+            // native timeout, so an unbounded call here could hang indefinitely if that
+            // nameserver is unreachable. Falls through the same way on any resolution failure or
+            // timeout rather than failing the connection outright.
+            if (!NextendoServerOverride.HorsNextendo &&
                 host.Contains("g23932a00", StringComparison.OrdinalIgnoreCase) &&
                 Environment.GetEnvironmentVariable("NEXTENDO_TENNIS_GEODNS") != "0")
             {

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Enumeration;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
 {
@@ -379,26 +380,40 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
             // [Nextendo] Mario Tennis Aces (NEX server id g23932a00) resolves through a real
             // GeoDNS hostname instead of the fixed NEXTENDO_SERVER_IP, so players get routed to
             // whichever of the two live Tennis nodes is actually closest to them. Every other
-            // title is unaffected -- the second node doesn't run their servers.
+            // title is unaffected -- the second node doesn't run their servers. Gated on
+            // !NextendoServerOverride.IsActive: a player running a custom/private server must
+            // not have Tennis silently pulled onto our nodes instead of theirs (caught in
+            // review -- this branch used to run ahead of Substituer()'s override check).
             // NEXTENDO_TENNIS_GEODNS=0 disables this and falls through to the normal built-in
-            // redirect below. Falls through the same way on any resolution failure (GeoDNS
-            // server unreachable, etc.) rather than failing the connection outright.
-            if (host.Contains("g23932a00", StringComparison.OrdinalIgnoreCase) &&
+            // redirect below. The lookup is bounded to 2s: the GeoDNS delegation has only one
+            // nameserver behind it, and Dns.GetHostEntry has no native timeout, so an unbounded
+            // call here could hang indefinitely if that nameserver is unreachable. Falls through
+            // the same way on any resolution failure or timeout rather than failing the
+            // connection outright.
+            if (!NextendoServerOverride.IsActive &&
+                host.Contains("g23932a00", StringComparison.OrdinalIgnoreCase) &&
                 Environment.GetEnvironmentVariable("NEXTENDO_TENNIS_GEODNS") != "0")
             {
                 try
                 {
-                    IPHostEntry geoEntry = Dns.GetHostEntry("tennis-geo.nextendo.network");
+                    Task<IPHostEntry> lookup = Task.Run(() => Dns.GetHostEntry("tennis-geo.nextendo.network"));
 
-                    Logger.Debug?.PrintMsg(LogClass.ServiceBsd, $"Redirecting '{host}' to: {geoEntry.AddressList[0]} (Tennis GeoDNS)");
-                    LastHostForIp[geoEntry.AddressList[0].ToString()] = host;
-
-                    return new IPHostEntry
+                    if (lookup.Wait(TimeSpan.FromSeconds(2)))
                     {
-                        AddressList = geoEntry.AddressList,
-                        HostName = host,
-                        Aliases = [],
-                    };
+                        IPHostEntry geoEntry = lookup.Result;
+
+                        Logger.Debug?.PrintMsg(LogClass.ServiceBsd, $"Redirecting '{host}' to: {geoEntry.AddressList[0]} (Tennis GeoDNS)");
+                        LastHostForIp[geoEntry.AddressList[0].ToString()] = host;
+
+                        return new IPHostEntry
+                        {
+                            AddressList = geoEntry.AddressList,
+                            HostName = host,
+                            Aliases = [],
+                        };
+                    }
+
+                    Logger.Warning?.PrintMsg(LogClass.ServiceBsd, "Tennis GeoDNS lookup timed out after 2s, falling back to fixed IP");
                 }
                 catch (Exception ex)
                 {

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -376,6 +376,36 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                 };
             }
 
+            // [Nextendo] Mario Tennis Aces (NEX server id g23932a00) resolves through a real
+            // GeoDNS hostname instead of the fixed NEXTENDO_SERVER_IP, so players get routed to
+            // whichever of the two live Tennis nodes is actually closest to them. Every other
+            // title is unaffected -- the second node doesn't run their servers.
+            // NEXTENDO_TENNIS_GEODNS=0 disables this and falls through to the normal built-in
+            // redirect below. Falls through the same way on any resolution failure (GeoDNS
+            // server unreachable, etc.) rather than failing the connection outright.
+            if (host.Contains("g23932a00", StringComparison.OrdinalIgnoreCase) &&
+                Environment.GetEnvironmentVariable("NEXTENDO_TENNIS_GEODNS") != "0")
+            {
+                try
+                {
+                    IPHostEntry geoEntry = Dns.GetHostEntry("tennis-geo.nextendo.network");
+
+                    Logger.Debug?.PrintMsg(LogClass.ServiceBsd, $"Redirecting '{host}' to: {geoEntry.AddressList[0]} (Tennis GeoDNS)");
+                    LastHostForIp[geoEntry.AddressList[0].ToString()] = host;
+
+                    return new IPHostEntry
+                    {
+                        AddressList = geoEntry.AddressList,
+                        HostName = host,
+                        Aliases = [],
+                    };
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"Tennis GeoDNS lookup failed, falling back to fixed IP: {ex.Message}");
+                }
+            }
+
             // [Nextendo] Built-in ordered rules take precedence (deterministic; most
             // specific first) so the wildcard can never swallow the nncs2 NAT-check host.
             if (TryMatchBuiltin(host, out IPAddress builtinAddress))


### PR DESCRIPTION
Tennis's redirected NEX host (server id g23932a00) now resolves through a real DNS hostname (tennis-geo.nextendo.network) instead of the fixed NEXTENDO_SERVER_IP substitution, so players get sent to whichever of the two live Tennis nodes is actually closest to them -- no per-player configuration needed. Every other title's redirect is unchanged; the second node only runs Tennis's server. Falls back to the normal built-in redirect on any resolution failure. NEXTENDO_TENNIS_GEODNS=0 disables it. Matches the equivalent citron change.