### PR TITLE
Add ARMS and Mario Tennis Aces to NextendoCompatibleVersion

### DIFF
--- a/src/Ryujinx/Systems/AppLibrary/ApplicationData.cs
+++ b/src/Ryujinx/Systems/AppLibrary/ApplicationData.cs
@@ -341,6 +341,8 @@ namespace Ryujinx.Ava.Systems.AppLibrary
             "0100dca0064a6000" => "1.4.0",  // Luigi's Mansion 3
             "0100c2500fc20000" => "11.2.0", // Splatoon 3
             "01006bd001e06000" => "1.0.17", // Minecraft: Nintendo Switch Edition
+            "01009b500007c000" => "5.5.1",  // ARMS
+            "0100bde00862a000" => "3.1.1",  // Mario Tennis Aces
             _ => "",
         };
 


### PR DESCRIPTION
Both titles are missing from the version-gate table, so they never get real online support: IsNextendoCompatible/IsNextendoVersionOk stayed false, keeping them out of the update-required gate and out of NextendoOnlineCounts' live player-count display (both already apply generically to any title where IsNextendoCompatible is true -- no other code changes needed). Versions match citron's nextendo_compatible_titles.h exactly (ARMS 5.5.1, Mario Tennis Aces 3.1.1), the source of truth since there's no server-side version-gate endpoint.