### PR TITLE
acc: include installed title version in the BAAS id_token

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
@@ -52,6 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
         private byte[] _cachedTokenData;
         private DateTime _cachedTokenExpiry;
+        private string _cachedTokenVersion;
 
         public ManagerServer(UserId userId)
         {
@@ -100,7 +101,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             return rsa;
         }
 
-        private static string GenerateIdToken()
+        private static string GenerateIdToken(string installedVersion)
         {
             RSAParameters parameters = _nextendoIdTokenRsa.ExportParameters(true);
 
@@ -142,6 +143,11 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             if (!string.IsNullOrEmpty(nexToken))
             {
                 claims["nnex"] = nexToken;
+            }
+
+            if (!string.IsNullOrEmpty(installedVersion))
+            {
+                claims["tv"] = installedVersion;
             }
 
             SecurityTokenDescriptor descriptor = new()
@@ -234,10 +240,14 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             }
             */
 
-            if (_cachedTokenData == null || DateTime.UtcNow > _cachedTokenExpiry)
+            string installedVersion = context.Device.Processes.ActiveApplication?.DisplayVersion;
+
+            if (_cachedTokenData == null || DateTime.UtcNow > _cachedTokenExpiry ||
+                installedVersion != _cachedTokenVersion)
             {
                 _cachedTokenExpiry = DateTime.UtcNow + TimeSpan.FromHours(3);
-                _cachedTokenData = Encoding.ASCII.GetBytes(GenerateIdToken());
+                _cachedTokenVersion = installedVersion;
+                _cachedTokenData = Encoding.ASCII.GetBytes(GenerateIdToken(installedVersion));
             }
 
             byte[] tokenData = _cachedTokenData;


### PR DESCRIPTION
Adds a "tv" claim (the installed title-update's display version, read from `ProcessResult.DisplayVersion`) to `GenerateIdToken()`'s BAAS id_token.

Right now version compatibility is enforced entirely client-side (`ApplicationData.NextendoCompatibleVersion`), which only blocks players on builds that actually have that table up to date. An old/unmaintained build has no such check at all and can still connect with a mismatched game update. This claim lets the NEX server itself verify the version independently of any client-side gate.

Companion changes: NextendoNetwork/nextendo-nex (parses the new claim) and NextendoNetwork/super-smash-bros-ultimate (enforces it, env-gated via `NEXTENDO_REQUIRED_VERSION`). Tested end-to-end against the Nextendo test VPS: a client honestly reporting an old version is now rejected server-side even with the client-side gate disabled.